### PR TITLE
Update hs-fulda example for new OpenStack

### DIFF
--- a/examples/hs-fulda/README.md
+++ b/examples/hs-fulda/README.md
@@ -7,15 +7,30 @@ This example implements the deactivation of the validation of all TLS certificat
 
 ## Usage
 
+### Requirements
+
+#### Linux
+The final step fetches the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` automatically using `rsync` and `yq`. Note that `rsync` is typically pre-installed on most Linux distributions. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
+
+#### Windows
+The final step requires `rsync` and `yq`, which are not available by default on Windows. You have multiple options to handle this (see the table below).
+
+| Method          | Description                                                              | Commands/Instructions                                                                                       |
+|-----------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| **SSH**         | Manually log in and fetch `rke2.yaml` by assigning a temporary floating IP | ```sh <br> ssh ubuntu@<floating-ip> <br> ```                                                               |
+| **SCP**         | Use `scp` to copy the `kubeconfig` file by assigning a temporary floating IP | ```sh <br> scp ubuntu@<floating-ip>:/etc/rancher/rke2/CloudComp<your-group-number>-k8s.rke2.yaml . <br> ``` |
+| **WSL/WSL2**    | Use Windows Subsystem for Linux (WSL/WSL2) to run Terraform              | Install `yq` from [here](https://github.com/mikefarah/yq/releases).                                         |
+| **Install rsync and yq** | Install `rsync` and `yq` on Windows                                 | Install `rsync` from [here](https://www.rsync.net/resources/howto/windows_rsync.html) and `yq` from [here](https://github.com/mikefarah/yq/releases). |
+
 ### Step 1: Clone the Repository
 
 ```sh
-git clone https://github.com/Stinktopf/terraform-openstack-rke2.git
+git clone https://github.com/srieger1/terraform-openstack-rke2.git
 ```
 
 ### Step 2: Configure Terraform Variables
 
-Navigate to the `example/hs-fulda` folder and create a `terraform.tfvars` file with your OpenStack credentials:
+Navigate to the `examples/hs-fulda` folder and create a `terraform.tfvars` file with your OpenStack credentials:
 
 ```hcl
 project  = "CloudComp<your-group-number>"
@@ -25,7 +40,7 @@ password = "<your-password>"
 
 ### Step 3: Initialize and Apply Terraform
 
-Run the following commands inside the folder:
+Run the following commands inside the `examples/hs-fulda` folder:
 
 ```sh
 terraform init
@@ -35,76 +50,148 @@ terraform apply
 ### Step 4: Fetch kubeconfig File
 
 #### Linux Users
-
-The final step fetches the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` automatically using `rsync` and `yq`. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
+The final step fetches the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` automatically using `rsync` and `yq`. Note that `rsync` is typically pre-installed on most Linux distributions. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
 
 #### Windows Users
-
-If running Terraform on Windows, fetching `rke2.yaml` via `ssh` and `rsync` will fail without `rsync` and `yq`. The RKE2 setup will still succeed. You have four options:
-
-**Option 1: SSH**
-
-Manually log in and fetch `rke2.yaml` by assigning a temporary floating IP:
-
-```sh
-ssh ubuntu@<floating-ip>
-```
-
-**Option 2: SCP**
-
-Use `scp` to copy the `kubeconfig` file by assigning a temporary floating IP:
-
-```sh
-scp ubuntu@<floating-ip>:/etc/rancher/rke2/CloudComp<your-group-number>-k8s.rke2.yaml .
-```
-
-**Option 3: WSL**
-
-Use Windows Subsystem for Linux (WSL/WSL2) to run Terraform. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
-
-**Option 4: Install rsync and yq**
-
-Install `rsync` from [here](https://www.rsync.net/resources/howto/windows_rsync.html) and `yq` from [here](https://github.com/mikefarah/yq/releases).
+Since `rsync` and `yq` are not available by default on Windows, use one of the methods outlined in the table above to fetch the `kubeconfig` file.
 
 ### Step 5: Handle Deployment Issues
 
-If stages fail, rerun `terraform apply` to resume deployment. Modify cluster parameters (e.g., node count) in the [main.tf](https://github.com/srieger1/terraform-openstack-rke2/blob/main/examples/hs-fulda/main.tf) file and rerun `terraform apply`.
+If any stages fail, rerun `terraform apply` to resume the deployment. If needed, modify cluster parameters (e.g., node count) in the `main.tf` file and rerun `terraform apply`.
 
 ### Step 6: Use Your Kubernetes Cluster
 
-After deployment, use `kubectl`, `helm`, etc., with your RKE2 Kubernetes cluster:
+After deployment, set up your environment to use `kubectl`.
+
+#### For Linux Users:
+
+Set the `KUBECONFIG` environment variable:
 
 ```sh
 export KUBECONFIG=CloudComp<your-group-number>-k8s.rke2.yaml
+```
+
+To continuously monitor the status of nodes and pods, use the `watch` command:
+
+```sh
 watch kubectl get nodes,pods -o wide -n kube-system
 ```
 
-After about four minutes, all pods should be running in the kube-system namespace and you can deploy workloads, such as WordPress:
+#### For Windows Users (PowerShell):
+
+Set the `KUBECONFIG` environment variable:
+
+```powershell
+$env:KUBECONFIG = "CloudComp<your-group-number>-k8s.rke2.yaml"
+```
+
+To continuously monitor the status of nodes and pods, use the following loop in PowerShell:
+
+```powershell
+while ($true) {
+    kubectl get nodes,pods -o wide -n kube-system
+    Start-Sleep -Seconds 10
+    Clear-Host
+}
+```
+
+Within about four minutes, all pods should be running in the kube-system namespace. You can then deploy workloads, such as WordPress, using `helm`:
 
 ```sh
 helm install my-release oci://registry-1.docker.io/bitnamicharts/wordpress
 ```
 
-Check deployment status:
+To check the deployment status:
+
+#### For Linux:
 
 ```sh
 watch kubectl get svc,pv,pvc,pods -o wide --namespace default
 ```
 
-You can access WordPress using the `EXTERNAL-IP` from `kubectl get svc -n default -w my-release-wordpress`.
+#### For Windows (PowerShell):
+
+```powershell
+while ($true) {
+    kubectl get svc,pv,pvc,pods -o wide --namespace default
+    Start-Sleep -Seconds 10
+    Clear-Host
+}
+```
+
+Access WordPress using the `EXTERNAL-IP` from the following command:
+
+```sh
+kubectl get svc -n default -w my-release-wordpress
+```
 
 ### Step 7: Clean Up
 
-Before running `terraform destroy`, delete workloads:
+Before running `terraform destroy`, delete any workloads:
 
 ```sh
 helm uninstall my-release
 terraform destroy
 ```
 
-The WordPress Helm Chart creates volumes in OpenStack that need to be deleted manually. If these volumes are not deleted, it can cause issues with the available quotas.
+Manually delete volumes created by the WordPress Helm Chart in OpenStack to avoid quota issues.
 
-### Useful tools
+### Troubleshooting Tips
 
-- For managing multiple Kubernetes clusters, consider using [kubectx](https://github.com/ahmetb/kubectx). 
-- For an enhanced terminal-based UI for Kubernetes, try [k9s](https://github.com/derailed/k9s).
+#### Describe Resources
+Get detailed information about nodes, pods, services, or deployments:
+
+```sh
+kubectl describe <resource-type> <resource-name> -n <namespace>
+```
+
+Examples:
+- Nodes: `kubectl describe nodes`
+- Pods: `kubectl describe pod <pod-name> -n <namespace>`
+- Services: `kubectl describe service <service-name> -n <namespace>`
+- Deployments: `kubectl describe deployment <deployment-name> -n <namespace>`
+
+#### Check Pod Logs
+View logs of a specific pod. Note that a pod can have multiple containers. To find out which containers are running in a pod, use:
+
+```sh
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[*].name}'
+```
+
+Then, use the `-c <container-name>` option to specify a container if needed:
+
+```sh
+kubectl logs <pod-name> -n <namespace> -c <container-name>
+```
+
+#### Debug Pods
+Open an interactive shell in a pod:
+
+```sh
+kubectl exec -it <pod-name> -n <namespace> -- /bin/sh
+```
+
+These commands help diagnose and resolve issues in your Kubernetes cluster.
+
+###  Additional Resources
+
+#### Learning Material
+- **[Kubernetes Documentation](https://kubernetes.io/docs/home/):** Comprehensive guides and references for all aspects of Kubernetes.
+- **[Kubernetes: The Documentary](https://www.youtube.com/watch?v=BE77h7dmoQU):** A video about the origins of Kubernetes.
+- **[The Illustrated Children's Guide to Kubernetes](https://www.youtube.com/watch?v=4ht22ReBjno):** A fun, illustrated video explaining Kubernetes basics.
+- **[Never install locally](https://www.youtube.com/watch?v=J0NuOlA2xDc):** A video that introduces the concepts of containerisation and orchestration.
+- **[A Visual Guide on Troubleshooting Kubernetes Deployments](https://learnk8s.io/troubleshooting-deployments):** A visual guide to resolving common Kubernetes deployment issues.
+- **[Zero to JupyterHub with Kubernetes](https://z2jh.jupyter.org/en/stable/):** A comprehensive guide to deploying and managing JupyterHub on Kubernetes. Great for learning with its step-by-step instructions and practical examples, suitable for both beginners and advanced users.
+
+
+#### Useful tools
+- **[Minikube](https://minikube.sigs.k8s.io/docs/):** A tool that enables you to run a local Kubernetes cluster.
+- **[Kustomize](https://kustomize.io/):** A tool for managing Kubernetes objects through composition of bases and overlays.
+- **[kubectx](https://github.com/ahmetb/kubectx):** For managing multiple Kubernetes clusters.
+- **[k9s](https://github.com/derailed/k9s):** For an enhanced terminal-based UI for Kubernetes.
+- **[Network Policy Editor](https://editor.networkpolicy.io/):** For easy editing of network policies.
+- **[Argo CD](https://argoproj.github.io/cd/):** A declarative, GitOps-based continuous delivery tool for Kubernetes.
+- **[Rancher](https://rancher.com/):** A complete Kubernetes management platform that simplifies cluster deployment and management.
+- **[Podman](https://podman.io/):** A tool for managing OCI containers and pods, serving as an alternative to Docker.
+
+

--- a/examples/hs-fulda/README.md
+++ b/examples/hs-fulda/README.md
@@ -3,6 +3,7 @@
 This guide outlines the steps to set up an RKE2 Kubernetes cluster on OpenStack using Terraform, based on [this repository](https://github.com/zifeo/terraform-openstack-rke2).
 
 ## Attention
+
 This example implements the deactivation of the validation of all TLS certificates by default. **Never** use this code in a production environment.
 
 ## Usage
@@ -10,17 +11,19 @@ This example implements the deactivation of the validation of all TLS certificat
 ### Requirements
 
 #### Linux
+
 The final step fetches the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` automatically using `rsync` and `yq`. Note that `rsync` is typically pre-installed on most Linux distributions. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
 
 #### Windows
+
 The final step requires `rsync` and `yq`, which are not available by default on Windows. You have multiple options to handle this (see the table below).
 
-| Method          | Description                                                              | Commands/Instructions                                                                                       |
-|-----------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| **SSH**         | Manually log in and fetch `rke2.yaml` by assigning a temporary floating IP | ```sh <br> ssh ubuntu@<floating-ip> <br> ```                                                               |
-| **SCP**         | Use `scp` to copy the `kubeconfig` file by assigning a temporary floating IP | ```sh <br> scp ubuntu@<floating-ip>:/etc/rancher/rke2/CloudComp<your-group-number>-k8s.rke2.yaml . <br> ``` |
-| **WSL/WSL2**    | Use Windows Subsystem for Linux (WSL/WSL2) to run Terraform              | Install `yq` from [here](https://github.com/mikefarah/yq/releases).                                         |
-| **Install rsync and yq** | Install `rsync` and `yq` on Windows                                 | Install `rsync` from [here](https://www.rsync.net/resources/howto/windows_rsync.html) and `yq` from [here](https://github.com/mikefarah/yq/releases). |
+| Method                   | Description                                                                  | Commands/Instructions                                                                                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SSH**                  | Manually log in and fetch `rke2.yaml` by assigning a temporary floating IP   | `ssh ubuntu@<floating-ip>`                                                                                                                            |
+| **SCP**                  | Use `scp` to copy the `kubeconfig` file by assigning a temporary floating IP | `scp ubuntu@<floating-ip>:/etc/rancher/rke2/CloudComp<your-group-number>-k8s.rke2.yaml`                                                               |
+| **WSL/WSL2**             | Use Windows Subsystem for Linux (WSL/WSL2) to run Terraform                  | Install `yq` from [here](https://github.com/mikefarah/yq/releases).                                                                                   |
+| **Install rsync and yq** | Install `rsync` and `yq` on Windows                                          | Install `rsync` from [here](https://www.rsync.net/resources/howto/windows_rsync.html) and `yq` from [here](https://github.com/mikefarah/yq/releases). |
 
 ### Step 1: Clone the Repository
 
@@ -49,10 +52,14 @@ terraform apply
 
 ### Step 4: Fetch kubeconfig File
 
+This step may take up to 10 minutes to complete as it involves setting up the cluster.
+
 #### Linux Users
-The final step fetches the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` automatically using `rsync` and `yq`. Note that `rsync` is typically pre-installed on most Linux distributions. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
+
+On Linux the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` is automatically fetched using `rsync` and `yq`. Note that `rsync` is typically pre-installed on most Linux distributions. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
 
 #### Windows Users
+
 Since `rsync` and `yq` are not available by default on Windows, use one of the methods outlined in the table above to fetch the `kubeconfig` file.
 
 ### Step 5: Handle Deployment Issues
@@ -119,11 +126,13 @@ while ($true) {
 }
 ```
 
-Access WordPress using the `EXTERNAL-IP` from the following command:
+Access WordPress using the `EXTERNAL-IP` from the `my-release-wordpress` LoadBalancer service:
 
 ```sh
 kubectl get svc -n default -w my-release-wordpress
 ```
+
+The allocation of `EXTERNAL-IP` can take a few minutes.
 
 ### Step 7: Clean Up
 
@@ -134,11 +143,12 @@ helm uninstall my-release
 terraform destroy
 ```
 
-Manually delete volumes created by the WordPress Helm Chart in OpenStack to avoid quota issues.
+Make sure that you delete the volumes, load balancers, floating IPs, ports in the network, the subnet in the network, the network and the security groups created by the WordPress Helm Chart in OpenStack if the deprovisioning of the Kubernetes cluster is stuck.
 
 ### Troubleshooting Tips
 
 #### Describe Resources
+
 Get detailed information about nodes, pods, services, or deployments:
 
 ```sh
@@ -146,12 +156,14 @@ kubectl describe <resource-type> <resource-name> -n <namespace>
 ```
 
 Examples:
+
 - Nodes: `kubectl describe nodes`
 - Pods: `kubectl describe pod <pod-name> -n <namespace>`
 - Services: `kubectl describe service <service-name> -n <namespace>`
 - Deployments: `kubectl describe deployment <deployment-name> -n <namespace>`
 
 #### Check Pod Logs
+
 View logs of a specific pod. Note that a pod can have multiple containers. To find out which containers are running in a pod, use:
 
 ```sh
@@ -165,6 +177,7 @@ kubectl logs <pod-name> -n <namespace> -c <container-name>
 ```
 
 #### Debug Pods
+
 Open an interactive shell in a pod:
 
 ```sh
@@ -173,9 +186,10 @@ kubectl exec -it <pod-name> -n <namespace> -- /bin/sh
 
 These commands help diagnose and resolve issues in your Kubernetes cluster.
 
-###  Additional Resources
+### Additional Resources
 
 #### Learning Material
+
 - **[Kubernetes Documentation](https://kubernetes.io/docs/home/):** Comprehensive guides and references for all aspects of Kubernetes.
 - **[Kubernetes: The Documentary](https://www.youtube.com/watch?v=BE77h7dmoQU):** A video about the origins of Kubernetes.
 - **[The Illustrated Children's Guide to Kubernetes](https://www.youtube.com/watch?v=4ht22ReBjno):** A fun, illustrated video explaining Kubernetes basics.
@@ -183,8 +197,8 @@ These commands help diagnose and resolve issues in your Kubernetes cluster.
 - **[A Visual Guide on Troubleshooting Kubernetes Deployments](https://learnk8s.io/troubleshooting-deployments):** A visual guide to resolving common Kubernetes deployment issues.
 - **[Zero to JupyterHub with Kubernetes](https://z2jh.jupyter.org/en/stable/):** A comprehensive guide to deploying and managing JupyterHub on Kubernetes. Great for learning with its step-by-step instructions and practical examples, suitable for both beginners and advanced users.
 
-
 #### Useful tools
+
 - **[Minikube](https://minikube.sigs.k8s.io/docs/):** A tool that enables you to run a local Kubernetes cluster.
 - **[Kustomize](https://kustomize.io/):** A tool for managing Kubernetes objects through composition of bases and overlays.
 - **[kubectx](https://github.com/ahmetb/kubectx):** For managing multiple Kubernetes clusters.
@@ -193,5 +207,3 @@ These commands help diagnose and resolve issues in your Kubernetes cluster.
 - **[Argo CD](https://argoproj.github.io/cd/):** A declarative, GitOps-based continuous delivery tool for Kubernetes.
 - **[Rancher](https://rancher.com/):** A complete Kubernetes management platform that simplifies cluster deployment and management.
 - **[Podman](https://podman.io/):** A tool for managing OCI containers and pods, serving as an alternative to Docker.
-
-

--- a/examples/hs-fulda/README.md
+++ b/examples/hs-fulda/README.md
@@ -1,0 +1,110 @@
+# HS-Fulda NetLab OpenStack RKE2 Example
+
+This guide outlines the steps to set up an RKE2 Kubernetes cluster on OpenStack using Terraform, based on [this repository](https://github.com/zifeo/terraform-openstack-rke2).
+
+## Attention
+This example implements the deactivation of the validation of all TLS certificates by default. **Never** use this code in a production environment.
+
+## Usage
+
+### Step 1: Clone the Repository
+
+```sh
+git clone https://github.com/Stinktopf/terraform-openstack-rke2.git
+```
+
+### Step 2: Configure Terraform Variables
+
+Navigate to the `example/hs-fulda` folder and create a `terraform.tfvars` file with your OpenStack credentials:
+
+```hcl
+project  = "CloudComp<your-group-number>"
+username = "CloudComp<your-group-number>"
+password = "<your-password>"
+```
+
+### Step 3: Initialize and Apply Terraform
+
+Run the following commands inside the folder:
+
+```sh
+terraform init
+terraform apply
+```
+
+### Step 4: Fetch kubeconfig File
+
+#### Linux Users
+
+The final step fetches the `kubeconfig` file for Kubernetes clients like `kubectl` and `helm` automatically using `rsync` and `yq`. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
+
+#### Windows Users
+
+If running Terraform on Windows, fetching `rke2.yaml` via `ssh` and `rsync` will fail without `rsync` and `yq`. The RKE2 setup will still succeed. You have four options:
+
+**Option 1: SSH**
+
+Manually log in and fetch `rke2.yaml` by assigning a temporary floating IP:
+
+```sh
+ssh ubuntu@<floating-ip>
+```
+
+**Option 2: SCP**
+
+Use `scp` to copy the `kubeconfig` file by assigning a temporary floating IP:
+
+```sh
+scp ubuntu@<floating-ip>:/etc/rancher/rke2/CloudComp<your-group-number>-k8s.rke2.yaml .
+```
+
+**Option 3: WSL**
+
+Use Windows Subsystem for Linux (WSL/WSL2) to run Terraform. Install `yq` from [here](https://github.com/mikefarah/yq/releases).
+
+**Option 4: Install rsync and yq**
+
+Install `rsync` from [here](https://www.rsync.net/resources/howto/windows_rsync.html) and `yq` from [here](https://github.com/mikefarah/yq/releases).
+
+### Step 5: Handle Deployment Issues
+
+If stages fail, rerun `terraform apply` to resume deployment. Modify cluster parameters (e.g., node count) in the [main.tf](https://github.com/srieger1/terraform-openstack-rke2/blob/main/examples/hs-fulda/main.tf) file and rerun `terraform apply`.
+
+### Step 6: Use Your Kubernetes Cluster
+
+After deployment, use `kubectl`, `helm`, etc., with your RKE2 Kubernetes cluster:
+
+```sh
+export KUBECONFIG=CloudComp<your-group-number>-k8s.rke2.yaml
+watch kubectl get nodes,pods -o wide -n kube-system
+```
+
+After about four minutes, all pods should be running in the kube-system namespace and you can deploy workloads, such as WordPress:
+
+```sh
+helm install my-release oci://registry-1.docker.io/bitnamicharts/wordpress
+```
+
+Check deployment status:
+
+```sh
+watch kubectl get svc,pv,pvc,pods -o wide --namespace default
+```
+
+You can access WordPress using the `EXTERNAL-IP` from `kubectl get svc -n default -w my-release-wordpress`.
+
+### Step 7: Clean Up
+
+Before running `terraform destroy`, delete workloads:
+
+```sh
+helm uninstall my-release
+terraform destroy
+```
+
+The WordPress Helm Chart creates volumes in OpenStack that need to be deleted manually. If these volumes are not deleted, it can cause issues with the available quotas.
+
+### Useful tools
+
+- For managing multiple Kubernetes clusters, consider using [kubectx](https://github.com/ahmetb/kubectx). 
+- For an enhanced terminal-based UI for Kubernetes, try [k9s](https://github.com/derailed/k9s).

--- a/examples/hs-fulda/main.tf
+++ b/examples/hs-fulda/main.tf
@@ -1,0 +1,132 @@
+locals {
+    insecure         = true
+    auth_url         = "https://10.32.4.182:5000/v3"
+    object_store_url = "private-cloud2.informatik.hs-fulda.de:6780"
+    region           = "RegionOne"
+
+    cluster_name     = "${var.project}-k8s"
+    image_name       = "ubuntu-22.04-jammy-x86_64"
+    flavor_name      = "m1.medium"
+    system_user      = "ubuntu"
+    floating_ip_pool = "ext_net"
+    ssh_pubkey_file  = "~/.ssh/id_ed25519.pub"
+    dns_server       = "10.33.16.100"
+    manifests_folder = "../../manifests"
+    rke2_version     = "v1.28.4+rke2r1"
+}
+
+module "rke2" {
+  source = "./../.."
+  insecure            = local.insecure
+  bootstrap           = true
+  name                = local.cluster_name
+  ssh_authorized_keys = [local.ssh_pubkey_file]
+  floating_pool       = local.floating_ip_pool
+  rules_ssh_cidr      = "0.0.0.0/0"
+  rules_k8s_cidr      = "0.0.0.0/0"
+  manifests_folder    = local.manifests_folder
+
+  servers = [{
+    name = "server"
+    flavor_name = local.flavor_name
+    image_name  = local.image_name
+    system_user = local.system_user
+    boot_volume_size = 8
+    rke2_version     = local.rke2_version
+    rke2_volume_size = 8
+    rke2_volume_device = "/dev/vdb"
+    rke2_config = <<EOF
+# https://docs.rke2.io/install/install_options/server_config/
+EOF
+  }]
+
+  agents = [
+    {
+      name        = "pool"
+      nodes_count = 3
+      flavor_name = local.flavor_name
+      image_name  = local.image_name
+      system_user = local.system_user
+      boot_volume_size = 8
+      rke2_version     = local.rke2_version
+      rke2_volume_size = 8
+      rke2_volume_device = "/dev/vdb"
+    }
+  ]
+
+  dns_nameservers4      = [local.dns_server]
+  ff_autoremove_agent   = "30s"
+  ff_write_kubeconfig   = true
+  ff_native_backup      = true
+  ff_wait_ready         = true
+
+  identity_endpoint     = local.auth_url
+  object_store_endpoint = local.object_store_url
+
+  kube_apiserver_resources = {
+    requests = {
+      cpu    = "75m"
+      memory = "128M"
+    }
+  }
+
+  kube_scheduler_resources = {
+    requests = {
+      cpu    = "75m"
+      memory = "128M"
+    }
+  }
+
+  kube_controller_manager_resources = {
+    requests = {
+      cpu    = "75m"
+      memory = "128M"
+    }
+  }
+
+  etcd_resources = {
+    requests = {
+      cpu    = "75m"
+      memory = "128M"
+    }
+  }
+
+  backup_schedule = "0 6 1 * *"
+  backup_retention = 20
+}
+
+variable "project" {
+  type = string
+}
+
+variable "username" {
+  type = string
+}
+
+variable "password" {
+  type = string
+}
+
+output "floating_ip" {
+  value = module.rke2.external_ip
+}
+
+provider "openstack" {
+  insecure    = local.insecure
+  tenant_name = var.project
+  user_name   = var.username
+  password    = var.password
+  auth_url    = local.auth_url
+  region      = local.region
+}
+
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = ">= 1.53.0"
+    }
+  }
+}

--- a/examples/hs-fulda/main.tf
+++ b/examples/hs-fulda/main.tf
@@ -1,4 +1,22 @@
+###########################################################
+# 
+# Author: Lucas Immanuel Nickel
+# Date: May 23, 2024
+# Remark: This code is not production ready as it disables certificate checks by default.
+#
+###########################################################
+
 locals {
+    ###########################################################
+    #
+    # Config parameters
+    #
+    # also add terraform.tfvars, see README at:
+    #
+    # https://github.com/srieger1/terraform-openstack-rke2/tree/hsfulda-example-2023-10/examples/hs-fulda
+    #
+    ###########################################################
+
     insecure         = true
     auth_url         = "https://10.32.4.182:5000/v3"
     object_store_url = "private-cloud2.informatik.hs-fulda.de:6780"
@@ -13,6 +31,8 @@ locals {
     dns_server       = "10.33.16.100"
     manifests_folder = "../../manifests"
     rke2_version     = "v1.28.4+rke2r1"
+
+    ###########################################################
 }
 
 module "rke2" {

--- a/examples/hs-fulda/main.tf
+++ b/examples/hs-fulda/main.tf
@@ -146,7 +146,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = ">= 1.53.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/examples/hs-fulda/terraform.tfvars.example
+++ b/examples/hs-fulda/terraform.tfvars.example
@@ -1,0 +1,3 @@
+username="CloudComp24"
+project="CloudComp24"
+password="<your-password>"

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ module "servers" {
         app_id           = openstack_identity_application_credential_v3.rke2.id
         app_secret       = openstack_identity_application_credential_v3.rke2.secret
         app_name         = openstack_identity_application_credential_v3.rke2.name
+        insecure         = var.insecure
       }),
       "velero.yaml" : templatefile("${path.module}/manifests/velero.yaml.tpl", {
         auth_url      = var.identity_endpoint
@@ -100,6 +101,7 @@ module "servers" {
         floating_network_id = data.openstack_networking_network_v2.floating_net.id
         lb_provider         = var.lb_provider
         cluster_name        = var.name
+        insecure            = var.insecure
       }),
       "patches/rke2-cilium.yaml" : templatefile("${path.module}/patches/rke2-cilium.yaml.tpl", {
         operator_replica = local.operator_replica

--- a/manifests/cloud-controller-openstack.yaml.tpl
+++ b/manifests/cloud-controller-openstack.yaml.tpl
@@ -34,6 +34,7 @@ spec:
         application-credential-secret: ${app_secret}
         region: ${region}
         tenant-id: ${project_id}
+        tls-insecure: ${insecure}
       loadBalancer:
         %{~ if floating_network_id != null ~}
         floating-network-id: ${floating_network_id}

--- a/manifests/csi-cinder.yaml.tpl
+++ b/manifests/csi-cinder.yaml.tpl
@@ -85,6 +85,7 @@ spec:
           application-credential-secret = ${app_secret}
           region = ${region}
           tenant-id = ${project_id}
+          tls-insecure = ${insecure}
           [BlockStorage]
           ignore-volume-az = true
           rescan-on-resize = true

--- a/node/versions.tf
+++ b/node/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "~> 1.53.0"
+      version = "~> 2.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   type = string
 }
 
+variable "insecure" {
+  type    = bool
+  default = false
+}
+
 variable "ssh_authorized_keys" {
   type    = list(string)
   default = ["~/.ssh/id_rsa.pub"]

--- a/versions.tf
+++ b/versions.tf
@@ -12,8 +12,8 @@ terraform {
     }
     openstack = {
       source = "terraform-provider-openstack/openstack"
-      # 1.5x.x is affected by https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1601
-      version = "~> 1.53.0"
+      # 2.0.x is maybe affected by https://github.com/terraform-provider-openstack/terraform-provider-openstack/issues/1601
+      version = "~> 2.0.0"
     }
   }
 }


### PR DESCRIPTION
# Changelog
- The `/hs-fulda` example has been adapted to the new OpenStack environment.
- The RKE version has been updated to version `v1.28.4+rke2r1`.
- The Terraform OpenStack Provider has been updated to version `2.0.0`.
- The identifiers for resources in OpenStack have been adapted to the new environment.
- The option of deactivating the certificate check has been added.
- The `README.md` has been adapted to the changes and expanded.