### PR TITLE
feat: add support for rke registry config

### DIFF
--- a/examples/hs-fulda/main.tf
+++ b/examples/hs-fulda/main.tf
@@ -135,7 +135,7 @@ EOF
     mirrors = {
       "*": {
         endpoint = [
-          "https://docker.cs.hs-fulda.de"
+          "https://harbor.cs.hs-fulda.de"
         ]
       }
     }

--- a/examples/hs-fulda/main.tf
+++ b/examples/hs-fulda/main.tf
@@ -130,6 +130,16 @@ EOF
 
   identity_endpoint     = local.auth_url
   object_store_endpoint = local.object_store_url
+
+  registries = {
+    mirrors = {
+      "*": {
+        endpoint = [
+          "https://docker.cs.hs-fulda.de"
+        ]
+      }
+    }
+  }
 }
 
 variable "project" {

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "servers" {
   image_uuid       = each.value.image_uuid
   boot_volume_size = each.value.boot_volume_size
   boot_volume_type = each.value.boot_volume_type
+  registries  = var.registries
 
   availability_zones = coalesce(each.value.availability_zones, [])
   group_id           = each.value.group_id != null ? each.value.group_id : openstack_compute_servergroup_v2.servers.id
@@ -196,6 +197,7 @@ module "agents" {
   image_uuid       = each.value.image_uuid
   boot_volume_size = each.value.boot_volume_size
   boot_volume_type = each.value.boot_volume_type
+  registries  = var.registries
 
   availability_zones = coalesce(each.value.availability_zones, [])
   group_id           = each.value.group_id != null ? each.value.group_id : openstack_compute_servergroup_v2.agents.id

--- a/node/cloud-init.yaml.tpl
+++ b/node/cloud-init.yaml.tpl
@@ -287,7 +287,7 @@ write_files:
       %{ endfor ~}
     %{~ endif ~}
 %{~ endif ~}
-%{ if registries != null ~}
+%{ if registries != null }
 - path: /etc/rancher/rke2/registries.yaml
   permissions: "0600"
   owner: root:root

--- a/node/cloud-init.yaml.tpl
+++ b/node/cloud-init.yaml.tpl
@@ -287,6 +287,13 @@ write_files:
       %{ endfor ~}
     %{~ endif ~}
 %{~ endif ~}
+%{ if registries != null ~}
+- path: /etc/rancher/rke2/registries.yaml
+  permissions: "0600"
+  owner: root:root
+  content: |
+    ${ indent(4, yamlencode(registries)) }
+%{~ endif ~}
 
 runcmd:
   - mkdir -p /mnt /var/lib/rancher/rke2 /var/lib/kubelet

--- a/node/main.tf
+++ b/node/main.tf
@@ -131,6 +131,7 @@ resource "openstack_compute_instance_v2" "instance" {
     ff_with_kubeproxy  = var.ff_with_kubeproxy
     node_taints  = var.node_taints
     node_labels  = var.node_labels
+    registries = var.registries
   }))
 }
 

--- a/node/variables.tf
+++ b/node/variables.tf
@@ -255,4 +255,28 @@ variable "node_taints" {
 
 variable "node_labels" {
   type    = map(string)
-} 
+}
+
+variable "registries" {
+  type = object({
+    mirrors = optional(map(object({
+      endpoint = list(string)
+      rewrite  = optional(map(string))
+    })))
+    configs = optional(map(object({
+      auth = optional(object({
+        username : optional(string)
+        password : optional(string)
+        token    : optional(string)
+      }))
+      tls = optional(object({
+        ca_file                : optional(string)
+        cert_file              : optional(string)
+        key_file               : optional(string)
+        insecure_skip_verify   : optional(bool)
+      }))
+    })))
+  })
+
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -340,3 +340,27 @@ variable "ff_with_kubeproxy" {
   type    = bool
   default = false
 }
+
+variable "registries" {
+  type = object({
+    mirrors = optional(map(object({
+      endpoint = list(string)
+      rewrite  = optional(map(string))
+    })))
+    configs = optional(map(object({
+      auth = optional(object({
+        username : optional(string)
+        password : optional(string)
+        token    : optional(string)
+      }))
+      tls = optional(object({
+        ca_file                : optional(string)
+        cert_file              : optional(string)
+        key_file               : optional(string)
+        insecure_skip_verify   : optional(bool)
+      }))
+    })))
+  })
+
+  default = null
+}


### PR DESCRIPTION
Added `/etc/rancher/rke2/registries.yaml` file generation in cloud-init

Has not been tested e2e but in two isolated steps:
- File generated correctly through terraform in openstack instance
- Existence of this file allowed pull-through-cache behavior for all registries (docker.io, quay.io etc except registry.k8s.io not sure why) on rke2 on my local machine